### PR TITLE
Fix continue format to match spec

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ static_path = None
 #see https://docs.python.org/3/library/struct.html for what these characters mean
 packet_format = "<BI"
 connect_format = "<BH"
-continue_format = "<B"
+continue_format = "<I"
 close_format = "<B"
 
 class WSProxyConnection:


### PR DESCRIPTION
Buffer remaining is a uint32 not a unsigned char as it was incorrectly labeled.﻿

Credit to @r58Playz for pointing it out
